### PR TITLE
Fix for Typescript version and output path 

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "awesome-typescript-loader": "^2.2.4",
     "css-loader": "^0.25.0",
     "style-loader": "^0.13.1",
-    "typescript": "^2.0.6",
+    "typescript": "2.0.10",
     "webpack": "^2.1.0-beta.25",
     "webpack-dev-server": "^2.1.0-beta.10"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,7 @@ const config = {
         ]
     },
     output: {
-        path: '/build',
+        path: __dirname + '/build',
         filename: 'app.bundle.js',
         publicPath: '/dev/'
     },


### PR DESCRIPTION
The project wouldn't build or run the dev server due to a newer version of typescript breaking the build and the output path set to the root directory. 
